### PR TITLE
Attempting to solve #447

### DIFF
--- a/src/Passage.js
+++ b/src/Passage.js
@@ -190,8 +190,23 @@ export default class Passage {
       content += ` ${JSON.stringify(this.metadata)}`;
     }
 
-    // Add newline, text, and two newlines.
-    content += `\n${this.text}\n\n`;
+    // Split the text into lines.
+    const lines = this.text.split('\n');
+
+    // For each line, check if it begins with a double-colon.
+    for (let i = 0; i < lines.length; i++) {
+      // Check if the line begins with a double-colon.
+      if (lines[i].startsWith('::')) {
+        // Escape the double-colon.
+        lines[i] = `\\${lines[i]}`;
+      }
+    }
+
+    // Rejoin the lines.
+    const output = lines.join('\n');
+
+    // Add newline and text.
+    content += `\n${output}\n\n`;
 
     // Return string.
     return content;

--- a/test/Objects/Passage.test.js
+++ b/test/Objects/Passage.test.js
@@ -240,5 +240,10 @@ describe('Passage', () => {
       expect(t.querySelector('tw-passagedata').getAttribute('tags')).toBe('&tag "bad"');
       expect(t.querySelector('tw-passagedata').getAttribute('position')).toBe('100,100');
     });
+
+    it('Should escape double-colon at start of text when exporting to Twee', function () {
+      const p = new Passage('test', ':: nefarious');
+      expect(p.toTwee()).toBe(':: test\n\\:: nefarious\n\n');
+    });
   });
 });


### PR DESCRIPTION
This solves the smaller problem of potentially creating passages whose _text_ contains lines starting with the `::` sigil and then exporting to Twee. In this specific case, Extwee will now escape the first colon and create the pattern of `\::` to match how Twine handles the same data pattern. This **does not** solve the larger issue of creating passage names containing special characters, which is much harder to solve without significant re-writing of how text parsing is handled.