### PR TITLE
Potential fix for code scanning alert no. 132: Incomplete multi-character sanitization

### DIFF
--- a/src/Twine2HTML/parse-web.js
+++ b/src/Twine2HTML/parse-web.js
@@ -119,7 +119,7 @@ class LightweightTwine2Parser {
   }
 
   extractTextContent(html) {
-    // Remove HTML tags and decode basic entities
+    // Remove HTML tags and decode basic entities, and strip any remaining angle brackets
     return html
       .replace(/<[^>]*>/g, '') // Remove HTML tags
       .replace(/&lt;/g, '<')
@@ -127,6 +127,7 @@ class LightweightTwine2Parser {
       .replace(/&quot;/g, '"')
       .replace(/&#39;/g, "'")
       .replace(/&amp;/g, '&') // This should be last
+      .replace(/[<>]/g, '') // Remove any remaining angle brackets to prevent injection
       .trim();
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/videlais/extwee/security/code-scanning/132](https://github.com/videlais/extwee/security/code-scanning/132)

The best fix is to ensure the sanitization of all potentially hazardous `<` and `>` characters, not just complete tag patterns. The simplest robust fix is to replace all literal `<` and `>` with empty strings, which ensures that any form of tag (well-formed or broken across multiple replacements) is eliminated, as recommended in the background material. Another strong approach is to use a reputable HTML sanitizer library, but since the context is about minimizing bundle size and avoiding dependencies, a repeated/complete replacement is best.

There are two general approaches:
1. Replace all `<` and `>` characters globally, after removing the tags and decoding entities.
2. Replace occurrences of `<` and `>` as entities as well as literals, to ensure that encoded and literal forms are eliminated.

Because the function already includes decoding of entities and a tag-strip step, it's best to add an explicit replacement of all `<` and `>` characters at the end. Edits are only needed in the `extractTextContent` method (lines 121-131).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
