### PR TITLE
Potential fix for code scanning alert no. 133: Exception text reinterpreted as HTML

### DIFF
--- a/docs/demos/compiler/index.html
+++ b/docs/demos/compiler/index.html
@@ -200,8 +200,19 @@ Behind the waterfall, you discover a secret cave filled with treasure!
             });
             
             // Show error message
+
+            // Escape HTML helper to prevent XSS
+            function escapeHtml(str) {
+                return String(str)
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#39;");
+            }
             function showError(message) {
-                $('#outputContainer').html(`<div class="error">❌ Error: ${message}</div>`);
+                // Escape the error message to prevent XSS
+                $('#outputContainer').html(`<div class="error">❌ Error: ${escapeHtml(message)}</div>`);
             }
             
             // Show success message  


### PR DESCRIPTION
Potential fix for [https://github.com/videlais/extwee/security/code-scanning/133](https://github.com/videlais/extwee/security/code-scanning/133)

To fix the vulnerability, escape special HTML characters in the error message before injecting it into the page. The best approach is to wrap the `message` in a function that converts `<`, `>`, `&`, `"`, and `'` to their HTML entity equivalents. You can add a utility function, e.g., `escapeHtml`, similar to what's used for outputting compiled HTML on line 290, and use it in `showError`.

**How to fix:**  
- Define (or reuse, if in scope) an `escapeHtml` function in the script region.
- Update the `showError` function (line 204) to wrap `message` with `escapeHtml`.
- Only change the problematic region; do not affect any other output/logic.

**Where:**  
- Inside `docs/demos/compiler/index.html`, in the `<script>` section.
- Lines 203–205: update `showError`.
- If no `escapeHtml` is defined above line 203, add it.
- Add a comment linking the fix to escaping for XSS safety.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
